### PR TITLE
Update L2.html

### DIFF
--- a/L2.html
+++ b/L2.html
@@ -453,6 +453,10 @@
                             <div class="detail-row">
                                 <span class="detail-label">Concerned Owner:</span>
                                 <span class="detail-value">${order.concernedOwner}</span>
+                            </div>	
+							<div class="detail-row">
+                                <span class="detail-label">L-1 Remark:</span>
+                                <span class="detail-value">${order.Remark.Lavel-1}</span>
                             </div>			
                             <div class="detail-row">
                                 <span class="detail-label">File:</span>


### PR DESCRIPTION
Add Remark

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - The Order Details panel now includes an “L-1 Remark” field, shown alongside “Concerned Owner” and “File.” This provides immediate visibility into level‑1 remarks directly within the details view. The field is read-only, styled consistently with existing rows, and appears when data is available. No other layout or behavioral changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->